### PR TITLE
Add jquery flag to catufol.json which, when set truthy, makes jquery …

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You may want to add a configuration file `catufol.json`:
 
     {
       "appName": "apps", // It will default to your project name in package.json if not provided
+      "useShimJQuery": true, // defaults to false, when true makes jQuery available globally in your app as `jQuery`, `$`, and `window.jQuery`
       "vendors": [
         "reflect-metadata",
         "es6-shim",
@@ -85,3 +86,9 @@ you are using AngularJS 2.0 it may look like this:
 * `-i` `--interactive` will run tests in interactive mode using Chrome
 * `-r` `--run` will run Webpack Development Server
 * `-b` `--build` will create the final artifacts using Webpack
+
+### Testing
+
+To run the tests, first install webpack locally (do not save or include in package.json) with `npm i webpack`.
+
+Run `npm test`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catufol",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Helper tool for Webpack based SPAs using TypeScript",
   "main": "./src/catufol.js",
   "scripts": {

--- a/src/config.js
+++ b/src/config.js
@@ -19,7 +19,8 @@ function Configuration (json) {
             buildPath: this.buildPath(),
             vendors: json.vendors.slice(),
             devEntryFile: json.devEntryFile || './app/main.ts',
-            prodEntryFile: json.prodEntryFile || './app/main.ts'
+            prodEntryFile: json.prodEntryFile || './app/main.ts',
+            useShimJQuery: !!json.useShimJQuery
         };
     };
     this.buildPath = function () { return json.buildPath || './build'; };
@@ -27,8 +28,16 @@ function Configuration (json) {
 }
 
 Configuration.prototype.wpBase = function () {
+    const plugins = [];
+    if (this.json().useShimJQuery) {
+        plugins.push(new webpack.ProvidePlugin({
+            $: "jquery",
+            jQuery: "jquery",
+            "window.jQuery": "jquery"
+        }));
+    }
     return {
-        plugins: [],
+        plugins: plugins,
         htmlLoader: wp.htmlLoader,
         tslint: wp.tslint,
         resolve: { extensions: wp.extensions },


### PR DESCRIPTION
…globally available in paired app as `jQuery`, `$`, and `window.jQuery`,

Bump package version,

Add documentation for running tests.
